### PR TITLE
Add `filename snippets` to `_.snip`.

### DIFF
--- a/neosnippets/_.snip
+++ b/neosnippets/_.snip
@@ -23,3 +23,19 @@ snippet     lastmod
 abbr        Last modified time
 alias       lmod
     Last Modified: `strftime("%Y-%m-%dT%H:%M:%S")`
+
+snippet     filename
+alias       fname
+options     word
+    `bufname('%') =='[Command Line]' ? expand('#:t:r:r:r') : expand('%:t:r:r:r')`${0}
+
+snippet     filename_upper_camel
+alias       fnameuc
+options     word
+    `substitute(bufname('%') =='[Command Line]' ? expand('#:t:r:r:r') : expand('%:t:r:r:r'), '\%(^\(.\)\|_\(.\)\)', '\u\1\u\2', 'g')`${0}
+
+snippet     filename_lower_camel
+alias       fnamelc
+options     word
+    `substitute(bufname('%') =='[Command Line]' ? expand('#:t:r:r:r') : expand('%:t:r:r:r'), '\%(_\(.\)\)', '\u\1', 'g')`${0}
+


### PR DESCRIPTION
### はじめに

filename を加工しながら出力するスニペットを追加してみました。
個人的にかなり便利に使っているのでどうでしょうか。
### 使用例
#### SampleClass.class.php

``` php
class fnameuc<Plug>(neosnippet-expand)
{

  public function __construct() {}

}
```

↓

``` php
class SampleClass
{

  public function __construct() {}

}
```
### その他

スニペット名が気に入らないなどありましたら、適宜治していただければと思います。
