### PR TITLE
Remove unnecessary brace in ruby.snip

### DIFF
--- a/neosnippets/ruby.snip
+++ b/neosnippets/ruby.snip
@@ -6,7 +6,7 @@ abbr        if ... end
 
 snippet     def
 abbr        def ... end
-  def ${1:#:method_name}{}
+  def ${1:#:method_name}
     ${2:TARGET}
   end
 


### PR DESCRIPTION
Rubyの`def`スニペットを呼び出すと、メソッド名の横に波括弧がついていたので修正しました。
## before

``` ruby
def #:method_name{}
  <`2:TARGET`>
end
```
## after

``` ruby
def #:method_name
  <`2:TARGET`>
end
```
