### PR TITLE
Fix missing escape in sh.snip

### DIFF
--- a/neosnippets/sh.snip
+++ b/neosnippets/sh.snip
@@ -69,12 +69,12 @@ options     head
 
 snippet     case
 options     head
-	case "$${1:{name}}" in
+	case "$${1:{name\}}" in
 		${2:pattern*})
 			${0}
 			;;
 		*)
-			${3:echo "$$1\} Didn't match anything"}
+			${3:echo "$$1 Didn't match anything"}
 	esac
 
 snippet     warn


### PR DESCRIPTION
sh.snip の case スニペットを展開する際に `$1` に変数名を与えると、変数名の後ろに`}`が残ります。

`$1`の中の`}`をエスケープして、`$3`の`\}`を取り除いて修正しました。

修正前：

``` sh
case "$hoge}" in                                                                 
  pattern*)                                                                      

    ;;                                                                           
  *)                                                                             
    echo "$hoge} Didn't match anything"                                          
esac
```

修正後：

``` sh
case "$hoge" in                                                                  
  pattern*)                                                                      

    ;;                                                                           
  *)                                                                             
    echo "$hoge Didn't match anything"                                           
esac
```
