### PR TITLE
Fix typo in the figure snippet of tex.snip

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -196,7 +196,8 @@ alias   \begin{figure} \figure
 	\begin{figure}
 		\centering
 		\includegraphics[${1:width=}]{${2}}
-		\caption{${3} \label{${4}}}
+		\caption{${3}}
+		\label{${4}}
 	\end{figure}
 
 snippet filecontents


### PR DESCRIPTION
Fixes a typo in the figure snippet of tex, where the label tag was inside the caption tag
