### PR TITLE
zsh snippet support as sh.snip

### DIFF
--- a/neosnippets/zsh.snip
+++ b/neosnippets/zsh.snip
@@ -1,0 +1,1 @@
+include sh.snip


### PR DESCRIPTION
grammar of zsh is mostly a superset of the sh.
Therefore,  I've included sh.snip to zsh.snip.
