### PR TITLE
Why do some whitespaces following function name exist? (Rust)

### DIFF
--- a/neosnippets/rust.snip
+++ b/neosnippets/rust.snip
@@ -3,21 +3,21 @@
 snippet     fn
 abbr        fn () {}
 options     head
-    fn ${1:#:func_name} (${2:#:args}) {
+    fn ${1:#:func_name}(${2:#:args}) {
         ${0:TARGET}
     }
 
 snippet     fn-
 abbr        fn () {}
 options     head
-    fn ${1:#:func_name} (${2:#:args}) -> ${3:#:()} {
+    fn ${1:#:func_name}(${2:#:args}) -> ${3:#:()} {
         ${0:TARGET}
     }
 
 snippet     pubfn
 abbr        pubfn () {}
 options     head
-    pub fn ${1:#:func_name} (${2:#:args}) -> ${3:#:()} {
+    pub fn ${1:#:func_name}(${2:#:args}) -> ${3:#:()} {
         ${0:TARGET}
     }
 


### PR DESCRIPTION
Prefer
```rust
fn foo() { 
}
```
over
```rust
fn foo () {
}
```
See [rust guide](http://aturon.github.io/style/whitespace.html).