### PR TITLE
tex.snip: fix typo and add snippets for beamer

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -35,7 +35,7 @@ alias   item[ \item[
 
 snippet it
 alias   item \item
-	\item $0
+	\item ${0}
 
 snippet sloppypar
 alias   \begin{sloppypar} \sloppypar

--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -349,6 +349,38 @@ alias   \begin{itshape} \itshape
 		${1:TARGET}
 	\end{itshape}
 
+# ==== BEAMER ====
+snippet frame
+alias  \begin{frame} \frame
+    \begin{frame}{${1:#:frametitle}}
+        ${2:TARGET}
+    \end{frame}
+
+snippet block
+alias \begin{block}
+    \begin{block}{${1:#:title}}
+        ${2:TARGET}
+    \end{block}
+
+snippet exampleblock
+alias \begin{exampleblock}
+    \begin{exampleblock}{${1:#:title}}
+        ${2:TARGET}
+    \end{exampleblock}
+
+snippet alertblock
+alias \begin{alertblock}
+    \begin{alertblock}{${1:#:title}}
+        ${2:TARGET}
+    \end{alertblock}
+
+snippet tikzpicture
+alias \begin{tikzpicture}
+    \begin{tikzpicture}
+        ${1:TARGET}
+    \end{tikzpicture}
+
+
 # ========== OTHERS ==========
 snippet usepackage
 alias   \usepackage


### PR DESCRIPTION
Just fixed typo of item in tex.snip, and added snippets that might be useful for beamer.