### PR TITLE
Enable to work eruby snippet when the cursor is immediately after the tag

### DIFF
--- a/neosnippets/eruby.snip
+++ b/neosnippets/eruby.snip
@@ -1,20 +1,25 @@
 snippet     ruby_print
 abbr        <%= %>
+options     word
     <%= ${1:TARGET} %>${2}
 
 snippet     ruby_code
 abbr        <% %>
+options     word
     <% ${1:TARGET} %>${2}
 
 snippet     ruby_print_nonl
 abbr        <%= -%>
+options     word
     <%= ${1:TARGET} -%>${2}
 
 snippet     ruby_code_nonl
 abbr        <% -%>
+options     word
     <% ${1:TARGET} -%>${2}
 
 snippet     comment
 abbr        <%# %>
+options     word
     <%# ${1:TARGET} %>${2}
 


### PR DESCRIPTION
When the cursor is immediately after the tag, neocomplete doesn't suggest snippet of eruby.

Procedure for reproducing
-------------------------

Use min.vim as vimrc, and edit test.erb
https://gist.github.com/pocke/15af0c621dd9ffd1c8a3

### Start vim

```sh
$ vim -u min.vim -N test.erb
```

### Input key

Input `llllliru`.

Before patch, neocomplete doesn't suggest `ruby_code`, `ruby_print`, etc.
After patch, neocomplete suggests those.