### PR TITLE
[rst.snip] Add indentation in code_block

### DIFF
--- a/neosnippets/rst.snip
+++ b/neosnippets/rst.snip
@@ -62,7 +62,7 @@ abbr code
 options head
   .. code-block :: ${1:#:filetype}
 
-    ${2:#:content}
+		${2:#:content}
 
 snippet link_raw
 abbr link_as_raw


### PR DESCRIPTION
Without this indentation, there will be no indentation after `C-k` move to content block when using `code_block` snippet.