### PR TITLE
Fix Python get/set attr snipppets and add hasattr

### DIFF
--- a/neosnippets/python.snip
+++ b/neosnippets/python.snip
@@ -119,11 +119,17 @@ abbr        # -*- coding ...
 
 snippet     getattr
 abbr        getattr(..., ...)
-    getattr(#:obj, #:attr)
+options     word
+    getattr(${1:#:obj}, ${2:#:attr})
 
 snippet     setattr
 abbr        setattr(..., ...)
-    setattr(#:obj, #:attr)
+    setattr(${1:#:obj}, ${2:#:attr}, ${3:#:value})
+
+snippet     hasattr
+abbr        hasattr(..., ...)
+options     word
+    hasattr(${1:#:obj}, ${2:#:attr})
 
 snippet     pdb
 abbr        import pdb..


### PR DESCRIPTION
The current `getattr` and `setattr` snippets don't work because the variable names are formatted incorrectly, `getattr` can only be used when preceded by whitespace (so for example `foo = func(getattr(obj, attr))` doesn't work), and `setattr` should take 3 arguments, not 2.