### PR TITLE
Add ${0} to date snippets

### DIFF
--- a/neosnippets/_.snip
+++ b/neosnippets/_.snip
@@ -2,27 +2,27 @@
 
 snippet     date
 options     word
-    `strftime("%d %b %Y")`
+    `strftime("%d %b %Y")`${0}
 
 snippet     date_full
 alias       df
 options     word
-    `strftime("%Y-%m-%dT%H:%M:%S")`
+    `strftime("%Y-%m-%dT%H:%M:%S")`${0}
 
 snippet     date_day
 alias       dd
 options     word
-    `strftime("%Y-%m-%d")`
+    `strftime("%Y-%m-%d")`${0}
 
 snippet     date_time
 alias       dt
 options     word
-    `strftime("%H:%M:%S")`
+    `strftime("%H:%M:%S")`${0}
 
 snippet     lastmod
 abbr        Last modified time
 alias       lmod
-    Last Modified: `strftime("%Y-%m-%dT%H:%M:%S")`
+    Last Modified: `strftime("%Y-%m-%dT%H:%M:%S")`${0}
 
 snippet     filename
 alias       fname


### PR DESCRIPTION
It seems the date snippets don't work properly. For some reason, when expanding `date_full`, the cursor does not end up at the end of the expanded text.