### PR TITLE
Improve module declaration for verilog snippets

### DIFF
--- a/neosnippets/verilog.snip
+++ b/neosnippets/verilog.snip
@@ -8,7 +8,7 @@ snippet beginend
     end
 
 snippet module
-    module ${1:name}(
+    module ${1:`expand("%:r")`}(
         ${2:TARGET}
     );
     endmodule


### PR DESCRIPTION
In verilog, we usually declare the module name as its file name. So I think it's better to set the default module name as its file name.