### PR TITLE
go: improve ife

### DIFF
--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -75,8 +75,9 @@ snippet     iferr
 alias       ife
 options     head
     if err != nil {
-      return`g:NeosnippetSnippets_Goiferr()`
+      return `g:NeosnippetSnippets_Goiferr()`
     }
+    ${2}
 
 snippet     switch
 abbr        switch {}

--- a/neosnippets/go.vim
+++ b/neosnippets/go.vim
@@ -45,5 +45,5 @@ function! g:NeosnippetSnippets_Goiferr() abort
     call add(rets, v)
   endfor
 
-  return '${1: ' . join(rets, ", ") . '}'
+  return '${1:' . join(rets, ", ") . '}'
 endfunction


### PR DESCRIPTION
* add `${2}` so another jump escapes it
* fix whitespace after expanding