### PR TITLE
Add case class snippet for scala

### DIFF
--- a/neosnippets/scala.snip
+++ b/neosnippets/scala.snip
@@ -94,5 +94,9 @@ snippet     package
 options     head
 	package `substitute(substitute(expand('%:h'), '.*\<src/\(main\|test\)/scala/', '', ''), '/', '.', 'g')`
 
+snippet     cclass
+abbr        case class ..(..: ..)
+	case class ${1}(${2}: ${0})
+
 # scala's indent plugin doesn't work well. use hard-tab for this snippet.
 # vim: set noexpandtab :


### PR DESCRIPTION
Adds `cclass` which expands to `case class ..(..: ..)`