### PR TITLE
[Ruby] Suggest camel cased filename as a class name.

### DIFF
--- a/neosnippets/ruby.snip
+++ b/neosnippets/ruby.snip
@@ -166,12 +166,12 @@ options     head
   end
 
 snippet     class
-  class ${1:#:Name}
+  class ${1:`substitute(expand('%:t:r:r:r'), '\v%(^(.)|_(.))', '\u\1\u\2', 'g')`}
     ${0}
   end
 
 snippet     module
-  module ${1:#:Name}
+  module ${1:`substitute(expand('%:t:r:r:r'), '\v%(^(.)|_(.))', '\u\1\u\2', 'g')`}
     ${0}
   end
 


### PR DESCRIPTION
For example. When editing `foo_bar.rb`, neosnippet expands the following code as `class` snippet.

```ruby
class FooBar
  
end
```


In many cases, class name is camel cased filename in Ruby.