### PR TITLE
tex.snip: remove defaull place holder 'TARGET'

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -12,19 +12,19 @@ abbr    $ expression $
 snippet begin
 alias   \begin
     \begin{${1:#:type}}
-        ${2:TARGET}
+        ${2}
     \end{$1}
 
 snippet list
 alias   \begin{list} \list
     \begin{list}
-        ${1:TARGET}
+        ${1}
     \end{list}
 
 snippet quotation
 alias   \begin{quotation} \quotation
     \begin{quotation}
-        ${1:TARGET}
+        ${1}
     \end{quotation}
 
 snippet description
@@ -44,55 +44,55 @@ alias   item \item
 snippet sloppypar
 alias   \begin{sloppypar} \sloppypar
     \begin{sloppypar}
-        ${1:TARGET}
+        ${1}
     \end{sloppypar}
 
 snippet enumerate
 alias   \begin{enumerate} \enumerate enum
     \begin{enumerate}
-        \item ${1:TARGET}
+        \item ${1}
     \end{enumerate}
 
 snippet theindex
 alias   \begin{theindex} \theindex
     \begin{theindex}
-        ${1:TARGET}
+        ${1}
     \end{theindex}
 
 snippet itemize
 alias   \begin{itemize} \itemize
     \begin{itemize}
-        \item ${1:TARGET}
+        \item ${1}
     \end{itemize}
 
 snippet titlepage
 alias   \begin{titlepage} \titlepage
     \begin{titlepage}
-        ${1:TARGET}
+        ${1}
     \end{titlepage}
 
 snippet verbatim
 alias   \begin{verbatim} verb \verbatim
     \begin{verbatim}
-        ${1:TARGET}
+        ${1}
     \end{verbatim}
 
 snippet verbatimtab
 alias   \begin{verbatimtab} \verbatimtab
     \begin{verbatimtab}[${1:8}]
-        ${2:TARGET}
+        ${2}
     \end{verbatim}
 
 snippet trivlist
 alias   \begin{trivlist} \trivlist
     \begin{trivlist}
-        ${1:TARGET}
+        ${1}
     \end{trivlist}
 
 snippet verse
 alias   \begin{verse} \verse
     \begin{verse}
-        ${1:TARGET}
+        ${1}
     \end{verse}
 
 snippet table
@@ -109,109 +109,109 @@ alias   \begin{table} \table
 snippet thebibliography
 alias   \begin{thebibliography} \thebibliography
     \begin{thebibliography}
-        ${1:TARGET}
+        ${1}
     \end{thebibliography}
 
 snippet tabbing
 alias   \begin{tabbing} \tabbing
     \begin{tabbing}
-        ${1:TARGET}
+        ${1}
     \end{tabbing}
 
 snippet note
 alias   \begin{note} \note
     \begin{note}
-        ${1:TARGET}
+        ${1}
     \end{note}
 
 snippet tabular
 alias   \begin{tabular} \tabular
     \begin{tabular}{${1}}
-        ${2:TARGET}
+        ${2}
     \end{tabular}
 
 snippet overlay
 alias   \begin{overlay} \overlay
     \begin{overlay}
-        ${1:TARGET}
+        ${1}
     \end{overlay}
 
 snippet array
 alias   \begin{array} \array
     \begin{array}{${1}}
-        ${2:TARGET}
+        ${2}
     \end{array}
 
 snippet cases
 alias   \begin{cases} \cases
     \begin{cases}{${1}}
-        ${2:TARGET}
+        ${2}
     \end{cases}
 
 snippet slide
 alias   \begin{slide} \slide
     \begin{slide}
-        ${1:TARGET}
+        ${1}
     \end{slide}
 
 snippet displaymath
 alias   \begin{displaymath} \displaymath
     \begin{displaymath}
-        ${1:TARGET}
+        ${1}
     \end{displaymath}
 
 snippet abstract
 alias   \begin{abstract} \abstract
     \begin{abstract}
-        ${1:TARGET}
+        ${1}
     \end{abstract}
 
 snippet align
 alias   \begin{align} \align
     \begin{align}
-        ${1:TARGET}
+        ${1}
     \end{align}
 
 snippet align*
 alias   \begin{align*} \align*
     \begin{align*}
-        ${1:TARGET}
+        ${1}
     \end{align*}
 
 snippet eqnarray
 alias   \begin{eqnarray} \eqnarray
     \begin{eqnarray}
-        ${1:TARGET}
+        ${1}
     \end{eqnarray}
 
 snippet eqnarray*
 alias   \begin{eqnarray*} \eqnarray*
     \begin{eqnarray*}
-        ${1:TARGET}
+        ${1}
     \end{eqnarray*}
 
 snippet equation
 alias   \begin{equation} \equation
     \begin{equation}
-        ${1:TARGET}
+        ${1}
     \end{equation}
 
 snippet equation*
 alias   \begin{equation*} \equation*
     \begin{equation*}
-        ${1:TARGET}
+        ${1}
     \end{equation*}
 
 snippet center
 alias   \begin{center} \center
     \begin{center}
-        ${1:TARGET}
+        ${1}
     \end{center}
 
 snippet document
 alias   \begin{document} \document
     \begin{document}
-        ${1:TARGET}
+        ${1}
     \end{document}
 
 snippet figure
@@ -226,85 +226,85 @@ alias   \begin{figure} \figure
 snippet filecontents
 alias   \begin{filecontents} \filecontents
     \begin{filecontents}
-        ${1:TARGET}
+        ${1}
     \end{filecontents}
 
 snippet lrbox
 alias   \begin{lrbox} \lrbox
     \begin{lrbox}
-        ${1:TARGET}
+        ${1}
     \end{lrbox}
 
 snippet flushleft
 alias   \begin{flushleft} \flushleft
     \begin{flushleft}
-        ${1:TARGET}
+        ${1}
     \end{flushleft}
 
 snippet flushright
 alias   \begin{flushright} \flushright
     \begin{flushright}
-        ${1:TARGET}
+        ${1}
     \end{flushright}
 
 snippet minipage
 alias   \begin{minipage} \minipage
     \begin{minipage}
-        ${1:TARGET}
+        ${1}
     \end{minipage}
 
 snippet picture
 alias   \begin{picture} \picture
     \begin{picture}
-        ${1:TARGET}
+        ${1}
     \end{picture}
 
 snippet math
 alias   \begin{math} \math
     \begin{math}
-        ${1:TARGET}
+        ${1}
     \end{math}
 
 snippet quote
 alias   \begin{quote} \quote
     \begin{quote}
-        ${1:TARGET}
+        ${1}
     \end{quote}
 
 snippet matrix
 alias   \begin{matrix} \matrix
     \begin{matrix}
-        ${1:TARGET}
+        ${1}
     \end{matrix}
 
 snippet bmatrix
 alias   \begin{bmatrix} \bmatrix
     \begin{bmatrix}
-        ${1:TARGET}
+        ${1}
     \end{bmatrix}
 
 snippet pmatrix
 alias   \pegin{bmatrix} \pmatrix
     \begin{pmatrix}
-        ${1:TARGET}
+        ${1}
     \end{pmatrix}
 
 snippet vmatrix
 alias   \begin{vmatrix} \vmatrix
     \begin{vmatrix}
-        ${1:TARGET}
+        ${1}
     \end{vmatrix}
 
 snippet Bmatrix
 alias   \begin{Bmatrix} \Bmatrix
     \begin{Bmatrix}
-        ${1:TARGET}
+        ${1}
     \end{Bmatrix}
 
 snippet Vmatrix
 alias   \begin{Vmatrix} \Vmatrix
     \begin{Vmatrix}
-        ${1:TARGET}
+        ${1}
     \end{Vmatrix}
 
 # ========== SECTION ==========
@@ -312,37 +312,37 @@ alias   \begin{Vmatrix} \Vmatrix
 snippet \part
 alias   part \part{
     \part{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \chapter
 alias   chapter \chapter{
     \chapter{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \section
 alias   section \section{
     \section{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \subsection
 alias   subsection \subsection{
     \subsection{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \subsubsection
 alias   subsubsection \subsubsection{
     \subsubsection{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \paragraph
 alias   paragraph \paragraph{
     \paragraph{${1}}
-    ${0:TARGET}
+    ${0}
 
 snippet \subparagraph
 alias   subparagraph \subparagraph{
     \subparagraph{${1}}
-    ${0:TARGET}
+    ${0}
 
 # ========== MATH ==========
 
@@ -360,116 +360,116 @@ abbr    \left \right
 snippet bfseries
 alias   \begin{bfseries} \bfseries
     \begin{bfseries}
-        ${1:TARGET}
+        ${1}
     \end{bfseries}
 
 snippet mdseries
 alias   \begin{mdseries} \mdseries
     \begin{mdseries}
-        ${1:TARGET}
+        ${1}
     \end{mdseries}
 
 snippet ttfamily
 alias   \begin{ttfamily} \ttfamily
     \begin{ttfamily}
-        ${1:TARGET}
+        ${1}
     \end{ttfamily}
 
 snippet sffamily
 alias   \begin{sffamily} \sffamily
     \begin{sffamily}
-        ${1:TARGET}
+        ${1}
     \end{sffamily}
 
 snippet rmfamily
 alias   \begin{rmfamily} \rmfamily
     \begin{rmfamily}
-        ${1:TARGET}
+        ${1}
     \end{rmfamily}
 
 snippet upshape
 alias   \begin{upshape} \upshape
     \begin{upshape}
-        ${1:TARGET}
+        ${1}
     \end{upshape}
 
 snippet slshape
 alias   \begin{slshape} \slshape
     \begin{slshape}
-        ${1:TARGET}
+        ${1}
     \end{slshape}
 
 snippet scshape
 alias   \begin{scshape} \scshape
     \begin{scshape}
-        ${1:TARGET}
+        ${1}
     \end{scshape}
 
 snippet itshape
 alias   \begin{itshape} \itshape
     \begin{itshape}
-        ${1:TARGET}
+        ${1}
     \end{itshape}
 
 snippet \textbf
 alias   textbf \textbf{
-    \textbf{${1:TARGET}}${0}
+    \textbf{${1}}${0}
 
 snippet \textmd
 alias   textmd \textmd{
-    \textmd{${1:TARGET}}${0}
+    \textmd{${1}}${0}
 
 snippet \texttt
 alias   texttt \texttt{
-    \texttt{${1:TARGET}}${0}
+    \texttt{${1}}${0}
 
 snippet \textsf
 alias   textsf \textsf{
-    \textsf{${1:TARGET}}${0}
+    \textsf{${1}}${0}
 
 snippet \textrm
 alias   textrm \textrm{
-    \textrm{${1:TARGET}}${0}
+    \textrm{${1}}${0}
 
 snippet \textup
 alias   textup \textup{
-    \textup{${1:TARGET}}${0}
+    \textup{${1}}${0}
 
 snippet \textsl
 alias   textsl \textsl{
-    \textsl{${1:TARGET}}${0}
+    \textsl{${1}}${0}
 
 snippet \textsc
 alias   textsc \textsc{
-    \textsc{${1:TARGET}}${0}
+    \textsc{${1}}${0}
 
 snippet \textit
 alias   textit \textit{
-    \textit{${1:TARGET}}${0}
+    \textit{${1}}${0}
 
 # ==== BEAMER ====
 snippet frame
 alias   \begin{frame} \frame
     \begin{frame}{${1:#:frametitle}}
-        ${2:TARGET}
+        ${2}
     \end{frame}
 
 snippet block
 alias   \begin{block}
     \begin{block}{${1:#:title}}
-        ${2:TARGET}
+        ${2}
     \end{block}
 
 snippet exampleblock
 alias   \begin{exampleblock}
     \begin{exampleblock}{${1:#:title}}
-        ${2:TARGET}
+        ${2}
     \end{exampleblock}
 
 snippet alertblock
 alias   \begin{alertblock}
     \begin{alertblock}{${1:#:title}}
-        ${2:TARGET}
+        ${2}
     \end{alertblock}
 
 snippet columns
@@ -490,7 +490,7 @@ alias   \begin{column} \column
 snippet tikzpicture
 alias   \begin{tikzpicture}
     \begin{tikzpicture}[${1}]
-        ${2:TARGET}
+        ${2}
     \end{tikzpicture}
 
 snippet path


### PR DESCRIPTION
`TARGET` is not appropriate for the default place holder and should not remain since it is completely meaningless.
`${number:TARGET}` should be `${number}` or `${number:#:TARGET}`, and I choose the former.
I'm not sure the difference between [`${number:default placeholder text}`](https://github.com/Shougo/neosnippet.vim/blob/master/doc/neosnippet.txt#L509) and [`${number:TARGET}`](https://github.com/Shougo/neosnippet.vim/blob/master/doc/neosnippet.txt#L543), though.