### PR TITLE
unconflict pn alias

### DIFF
--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -38,7 +38,7 @@ options     head
   fmt.Printf("${1}\n"${2:})
 
 snippet     println
-alias pn
+alias pl
 options     head
   fmt.Println(${0:TARGET})
 


### PR DESCRIPTION
`pn` conflicts with snippet from [vim-go](https://github.com/fatih/vim-go/blob/10c805b83f160eb9e7f9cbe00d26c1b6d06ba636/gosnippets/snippets/go.snip#L249-L253), which stands for `panic`. So `pl` is safe for use.
Thanks for your time!