### PR TITLE
Improved golang snippet iferr.

### DIFF
--- a/neosnippets/go.vim
+++ b/neosnippets/go.vim
@@ -34,7 +34,7 @@ function! g:NeosnippetSnippets_Goiferr() abort
     if t =~# '\v^\s*error\s*$'
       let v = 'err'
     elseif t =~# '\v^\s*string\s*$'
-      let v = '""'
+      let v = '"${1\}"'
     elseif t =~# '\v^\s*int\d*\s*$'
       let v = '0'
     elseif t =~# '\v^\s*bool\s*$'
@@ -45,5 +45,5 @@ function! g:NeosnippetSnippets_Goiferr() abort
     call add(rets, v)
   endfor
 
-  return '${1:' . join(rets, ", ") . '}'
+  return '${1:' . join(rets, ", ") . '${0\}}'
 endfunction


### PR DESCRIPTION
Improved golang snippet iferr creates placeholders available to jump to in place of strings returned from function.

Here is an example of unfolded iferr snippet for function returning some strings:
```
func foo() (string, bool, int, string, bool, error) {
	if err != nil {
		return "<`1`>", false, 0, "<`1`>", false, err<`0`>
	}
}
```

One can easily fill some data inside quotes using placeholders.