### PR TITLE
doubly escape backslash in default placeholder text

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -475,14 +475,14 @@ alias   \begin{alertblock}
 snippet columns
 alias   \begin{columns} \columns
     \begin{columns}
-        \begin{column}{${1:#:width}${2:\\textwidth}}
+        \begin{column}{${1:#:width}${2:\\\textwidth}}
             ${0:#:body}
         \end{column}
     \end{columns}
 
 snippet column
 alias   \begin{column} \column
-    \begin{column}{${1:#:width}${2:\\textwidth}}
+    \begin{column}{${1:#:width}${2:\\\textwidth}}
         ${0:#:body}
     \end{column}
 


### PR DESCRIPTION
Consider single-escaped default placeholder(s) in a snippet, the second one `\\textwidth` in this commit.
Snippet candidate is shown as `\\textwidth`;  a backslash `\` vanishes and the default placeholder text is `\textwidth` when the snippet is expanded; another `\` vanishes after jump to it, resulting in `textwidth`.
Double-escape, `\\\textwidth`, is required to obtain `\textwidth` as default.