### PR TITLE
Fix: go.snip

### DIFF
--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -117,9 +117,9 @@ options     head
   }
 
 snippet     funcbench
-abbr        func Bench... (b *testing.B) { ... }
+abbr        func Benchmark... (b *testing.B) { ... }
 options     head
-  func Bench${1} (${2:b *testing.B}) {
+  func Benchmark${1} (${2:b *testing.B}) {
     for i := 0; i < ${3:b.N}; i++ {
       ${4}
     }


### PR DESCRIPTION
Fix to follow naming convention.
"BenchmarkXxx" is correct, not "BenchXxx".

See https://golang.org/pkg/testing/#hdr-Benchmarks