### PR TITLE
fix name related issue with Goiferr

### DIFF
--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -82,7 +82,7 @@ snippet     iferr
 alias       ife
 options     head
     if err != nil {
-      return `g:NeosnippetSnippets_Goiferr()`
+      return `g:NeosnippetSnippets_GoIfErr()`
     }
     ${2}
 

--- a/neosnippets/go.vim
+++ b/neosnippets/go.vim
@@ -1,5 +1,5 @@
 " From http://pocke.hatenablog.com/entry/2015/12/20/133445
-function! g:NeosnippetSnippets_Goiferr() abort
+function! g:NeosnippetSnippets_GoIfErr() abort
   let re_func = '\vfunc'
   let re_type = '%(%([.A-Za-z0-9*]|\[|\]|%(%(struct)|%(interface)\{\}))+)'
   let re_rcvr = '%(\s*\(\w+\s+' . re_type . '\))?'


### PR DESCRIPTION
The Go `ife` snippet was working fine because it didn't match the regex here:
https://github.com/Shougo/neosnippet.vim/blob/master/autoload/neosnippet/parser.vim#L316

That regex was basically looking to see if the string contained `ife(`.

However, the `iferr` snippet was broken because it did match the regex with `iferr(`. By changing the casing of the function, it no longer matches.

Also of note, this only became an issue once I set `let g:deoplete#max_menu_width = 0`