### PR TITLE
ada.snip: Fix duplicate 'case' snippet

### DIFF
--- a/neosnippets/ada.snip
+++ b/neosnippets/ada.snip
@@ -107,7 +107,7 @@ abbr        if expression
 options     head
 	if ${1} then ${2} else ${0}
 
-snippet     case
+snippet     case_expression
 abbr        case expression
 options     head
 	case ${1} is


### PR DESCRIPTION
Two snippets have the same name, see https://github.com/Shougo/neosnippet-snippets/blob/5fadc11a40ff9e5c64371398c1752a1878377200/neosnippets/ada.snip#L110 and https://github.com/Shougo/neosnippet-snippets/blob/5fadc11a40ff9e5c64371398c1752a1878377200/neosnippets/ada.snip#L241
This PR fixes that.