### PR TITLE
Additional math environments for tex

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -7,6 +7,16 @@ alias   $
 abbr	$ expression $
 	$${1:#:expression}$${2}
 
+snippet mathenva
+alias   $$
+abbr    $$ expression $$
+        $$${1:#:expression}$$${2}
+
+snippet mathenvb
+alias   \[
+abbr    \[ expression \]
+        \[${1:#:expression}\]${2}
+
 # ========== ENVIRONMENT ==========
 
 snippet begin


### PR DESCRIPTION
I added two additional math environments, namely:
```tex
$$ expression $$
```
and 
```tex
\[ expression \]
```
they all do the same as
```tex
\begin{equation*}
    expression
\end{equation*}
```
but might be used by different users, including me.