### PR TITLE
Added new Doxygen style function documentation for C and assembly language

### DIFF
--- a/neosnippets/asm.snip
+++ b/neosnippets/asm.snip
@@ -1,0 +1,12 @@
+snippet     ;;
+abbr        ;; @brief
+options     head
+    ;;
+    ;; @brief      ${1:function description}
+    ;;
+    ;; @details    ${2:Detailed description}
+    ;;
+    ;; @param      ${3:param}
+    ;;
+    ;; @return     ${4:return}
+    ;;

--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -170,3 +170,15 @@ abbr fopen("...", "...");
 snippet fgets
 abbr fgets(row, length, file);
     fgets(${0:ROW}, ${1:LENGTH}, ${2:FILE});
+
+snippet     /**
+abbr        /** @brief
+options     head
+    /**
+     * @brief    ${1:function description}
+     *
+     * @details  ${2:detailed description}
+     *
+     * @param    ${3:param}
+     * @return   ${4:return type}
+     */


### PR DESCRIPTION
Extended C snippets with Doxygen style function documentation triggered using ```/**```.  This could be used for any high-level programming function documentation, e.g. Java, etc.  Maybe there is a better place to put this new documentation snippet to make it accessible to other languages also?

Added new assembly language Doxygen style function documentation triggered using ```;;```.

Both snippets use JavaDoc style ```@``` command format.  This is compliant with Doxygen:
[https://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmd_intro](url)