### PR TITLE
Updated c and asm snippet triggers

### DIFF
--- a/neosnippets/asm.snip
+++ b/neosnippets/asm.snip
@@ -1,10 +1,10 @@
-snippet     ;;
-abbr        ;; @brief
+snippet     doxy
+abbr        ;; @brief ...
 options     head
     ;;
     ;; @brief      ${1:function description}
     ;;
-    ;; @details    ${2:Detailed description}
+    ;; @details    ${2:detailed description}
     ;;
     ;; @param      ${3:param}
     ;;

--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -171,8 +171,8 @@ snippet fgets
 abbr fgets(row, length, file);
     fgets(${0:ROW}, ${1:LENGTH}, ${2:FILE});
 
-snippet     /**
-abbr        /** @brief
+snippet     doxy
+abbr        /** @brief ...
 options     head
     /**
      * @brief    ${1:function description}
@@ -180,5 +180,6 @@ options     head
      * @details  ${2:detailed description}
      *
      * @param    ${3:param}
+     *
      * @return   ${4:return type}
      */


### PR DESCRIPTION
Updated c and asm snippet triggers to ```doxy``` because the original triggers didn't work as they were interpreted as comments.  Also some minor formatting of snippet.