### PR TITLE
Final snippet and changing some placeholders

### DIFF
--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -172,10 +172,11 @@ abbr #ifndef ... #define ... #endif
     #define ${1:#:SYMBOL}
     #endif${0}
 
+# This snippet used the placeholder instead of a trailing space
 snippet     def
 options     head
 alias       #def, #define
-    #define
+    #define ${1}
 
 # Include-Guard
 snippet     once

--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -142,13 +142,19 @@ options     head
 snippet     inc
 options     head
 alias       #inc, #include
-    #include <${1:stdio}.h>${0}
+    #include <${1:stdio}.h>
 
 # #include "..."
 snippet     inc2
 options     head
 alias       #inc2, #include2
-    #include "${1}.h"${0}
+    #include "${1}.h"
+
+snippet     #if
+options     head
+    #if ${1}
+    ${0}
+    #endif
 
 snippet     ifdef
 options     head
@@ -174,7 +180,8 @@ alias       #def, #define
 # Include-Guard
 snippet     once
 options     head
-abbr        include-guard
+alias       include-guard
+abbr #ifndef ... #define ... #endif
     #ifndef ${1:#:SYMBOL}
         #define $1
 

--- a/neosnippets/java.snip
+++ b/neosnippets/java.snip
@@ -28,12 +28,20 @@ snippet const
 snippet const_string
     static public final String ${1:var} = "${2}";${4}
 
+snippet final
+    public final ${1:#:type} ${2:#:var} = ${3};
+
 snippet assert
     assert ${1:#:test} : ${2:#:Failure message};${3}
 
 snippet if
     if (${1}) {
         ${2:TARGET}
+    }
+
+snippet else
+    else {
+        ${1:TARGET}
     }
 
 snippet elif
@@ -160,11 +168,15 @@ snippet main
 
 snippet println
 options word
-    System.out.println(${1});${0}
+    System.out.println(${1});
 
 snippet print
 options word
-    System.out.print(${1});${0}
+    System.out.print(${1});
+
+snippet format
+options word
+    System.out.format(${1});
 
 #javadoc
 snippet comment


### PR DESCRIPTION
Add "final" snippet to java, to create final non-static variables.

Use a placeholder at the end of #define instead of a trailing space.

Delete some unnecessary placeholders in single line snippets.