### PR TITLE
Add 'alias foreach' to existing 'foreach-list'

### DIFF
--- a/neosnippets/php.snip
+++ b/neosnippets/php.snip
@@ -202,6 +202,7 @@ snippet foreach-hashmap
 	}
 
 snippet foreach-list
+alias foreach
 options head
 	foreach ($${1:#:variable} as $${2:#:x}) {
 		${0:TARGET}


### PR DESCRIPTION
Currently no `foreach` entry for PHP (existing entries: `pforeach`, `foreach-hashmap`, `foreach-list`).
I want `foreach` entry to expand to most generic foreach notation.