### PR TITLE
fix: add an empty line to follow PEP8/E301

### DIFF
--- a/neosnippets/python.snip
+++ b/neosnippets/python.snip
@@ -9,6 +9,7 @@ snippet     class
 abbr        class Class(...): ...
 options     head
 	class ${1:#:name}(${2:object}):
+
 		def __init__(self, ${3}):
 			${0:pass}
 
@@ -17,6 +18,7 @@ abbr        class Class(...): "..."
 options     head
 	class ${1:#:name}(${2:object}):
 		"""${3:#:class documentation}"""
+
 		def __init__(self, ${4}):
 			"""${5:#:__init__ documentation}"""
 			${0:pass}


### PR DESCRIPTION
**problem**  
current `class` and `classd` snippet for python provides like below, which causes pep8/E301(expected 1 blank line, found 0).

```python
class C(object):
    def __init__(self, ...)
```

**changes**  
- added blank line before `def __init__` for `class` and `classd` snippets
