### PR TITLE
Add aligned command from amsmath

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -188,6 +188,12 @@ alias   \begin{align*} \align*
 		${1:TARGET}
 	\end{align*}
 
+snippet aligned
+alias   \begin{aligned} \aligned
+       \begin{aligned}
+               ${1:TARGET}
+       \end{aligned}
+
 snippet eqnarray
 alias   \begin{eqnarray} \eqnarray
 	\begin{eqnarray}


### PR DESCRIPTION
I've added the aligned command from the amsmath package to the tex snippets. I prefer this style of aligning over align and align*.