### PR TITLE
Fix missing argument in tex minipage

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -265,8 +265,8 @@ alias   \begin{flushright} \flushright
 
 snippet minipage
 alias   \begin{minipage} \minipage
-	\begin{minipage}
-		${1:TARGET}
+	\begin{minipage}{${1:0.45}\linewidth}
+		${2:TARGET}
 	\end{minipage}
 
 snippet picture


### PR DESCRIPTION
The tex minipage snippet is missing the required width argument.
This PR adds an additional placeholder for the faction of the `\linewidth`, which is arguably the most common use case. The placeholder defaults to `0.45` which allow for 2 columns.