### PR TITLE
Only allow CSS property snippets after only whitespace or after a semicolon or open brace

### DIFF
--- a/neosnippets/css.snip
+++ b/neosnippets/css.snip
@@ -1,252 +1,315 @@
 snippet	background
 alias	bg
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background: ${1};${2}
 
 snippet	backattachment
 alias	ba
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background-attachment: ${1};${2}
 
 snippet	backcolor
 alias	bc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background-color: ${1};${2}
 
 snippet	backimage
 alias	bi
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background-image: ${1};${2}
 
 snippet	backposition
 alias	bp
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background-position: ${1};${2}
 
 snippet	backrepeat
 alias	br
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     background-repeat: ${1};${2}
 
 snippet	border
 alias	b
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border: ${1};${2}
 
 snippet	border-style
 alias	bs
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-style: ${1};${2}
 
 snippet	border-color
 alias	bc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-color: ${1};${2}
 
 snippet	border-width
 alias	bw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-width: ${1};${2}
 
 snippet	border-bottom-width
 alias	bbw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-bottom-width: ${1};${2}
 
 snippet	border-top-width
 alias	btw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-top-width: ${1};${2}
 
 snippet	border-left-width
 alias	blw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-left-width: ${1};${2}
 snippet	border-right-width
 alias	brw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-right-width: ${1};${2}
 
 
 snippet	border-bottom-style
 alias	bbs
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-bottom-style: ${1};${2}
 
 snippet	border-top-style
 alias	bts
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-top-style: ${1};${2}
 
 snippet	border-left-style
 alias	bls
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-left-style: ${1};${2}
 snippet	border-right-style
 alias	brs
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-right-style: ${1};${2}
 
 
 snippet	border-bottom-color
 alias	bbc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-bottom-color: ${1};${2}
 
 snippet	border-top-color
 alias	btc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-top-color: ${1};${2}
 
 snippet	border-left-color
 alias	blc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-left-color: ${1};${2}
 snippet	border-right-color
 alias	brc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     border-right-color: ${1};${2}
 
 snippet	outline
 alias	ol
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     outline: ${1};${2}
 
 snippet	outline-color
 alias	oc
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     outline-color: ${1};${2}
 
 snippet	outline-style
 alias	os
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     outline-style: ${1};${2}
 
 snippet	outline-width
 alias	ow
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     outline-width: ${1};${2}
 
 snippet	color
 alias	c
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     color: ${1};${2}
 
 snippet	direction
 alias	d
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     direction: ${1};${2}
 
 snippet	letter-spacing
 alias	ls
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     letter-spacing: ${1};${2}
 
 snippet	line-height
 alias	lh
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     line-height: ${1};${2}
 
 snippet	text-align
 alias	ta
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     text-align: ${1};${2}
 
 snippet	text-decoration
 alias	td
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     text-decoration: ${1};${2}
 
 snippet	text-indent
 alias	ti
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     text-indent: ${1};${2}
 
 snippet	text-transform
 alias	tt
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     text-transform: ${1};${2}
 
 snippet	unicode-bidi
 alias	ub
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     unicode-bidi: ${1};${2}
 
 snippet	white-space
 alias	ws
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     white-space: ${1};${2}
 
 snippet	word-spacing
 alias	ws
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     word-spacing: ${1};${2}
 
 snippet	font
 alias	f
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     font: ${1};${2}
 
 snippet	font-family
 alias	ff
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     font-family: ${1:"Times New Roman",Georgia,Serif};${2}
 
 snippet	font-size
 alias	fs
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     font-size: ${1};${2}
 
 snippet	font-style
 alias	fs
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     font-style: ${1};${2}
 
 snippet	font-weight
 alias	fw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     font-weight: ${1};${2}
 
 snippet	margin
 alias	m
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     margin: ${1};${2}
 
 snippet	margin-bottom
 alias	mb
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     margin-bottom: ${1};${2}
 
 snippet	margin-top
 alias	mt
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     margin-top: ${1};${2}
 
 snippet	margin-left
 alias	ml
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     margin-left: ${1};${2}
 
 snippet	margin-right
 alias	mr
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     margin-right: ${1};${2}
 
 snippet	padding
 alias	p
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     padding: ${1};${2}
 
 snippet	padding-bottom
 alias	pb
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     padding-bottom: ${1};${2}
 
 snippet	padding-top
 alias	pt
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     padding-top: ${1};${2}
 
 snippet	padding-left
 alias	pl
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     padding-left: ${1};${2}
 
 snippet	padding-right
 alias	pr
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     padding-right: ${1};${2}
 
 snippet	list-style
 alias	ls
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     list-style: ${1};${2}
 
 snippet	list-style-image
 alias	lsi
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     list-style-image: ${1};${2}
 
 snippet	list-style-position
 alias	lsp
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     list-style-position: ${1};${2}
 
 snippet	list-style-type
 alias	lst
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     list-style-type: ${1};${2}
 
 snippet	content
 alias	c
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     content: ${1};${2}
 
 snippet	height
 alias	h
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     height: ${1};${2}
 
 snippet	max-height
 alias	mah
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     max-height: ${1};${2}
 
 snippet	max-width
 alias	maw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     max-width: ${1};${2}
 
 snippet	min-height
 alias	mih
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     min-height: ${1};${2}
 
 snippet	min-width
 alias	miw
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     min-width: ${1};${2}
 
 snippet	width
 alias	w
+regexp	'\(^\s*[^:^ ]\+$\|^.*\(;\|{\)[^:]*$\)'
     width: ${1};${2}
 
 # For media query


### PR DESCRIPTION
Adding regex so CSS properties will only appear in certain contexts.

For instance, `backrepeat` will work in these contexts:

```css
div {
  backrepeat
```

```css
div { backrepeat
```

```css
div {
  color: blue; backrepeat
```

but not in these contexts:

```css
div backrepeat{
  color: backrepeat
```

```css
div backrepeat
```