### PR TITLE
Fix snippet indentation and syntax

### DIFF
--- a/neosnippets/ada.snip
+++ b/neosnippets/ada.snip
@@ -7,15 +7,15 @@ snippet     package
 abbr        package {NAME} is {...} end
 options     head
 	package ${1} is
-                ${0}
-        end $1;
+		${0}
+	end $1;
 
 
 snippet     package_body
 abbr        package body {NAME} is {...} end
 options     head
 	package body ${1} is
-                ${0}
+		${0}
 	end $1;
 
 snippet     entry
@@ -271,34 +271,34 @@ snippet     exit_when
 abbr        exit when
 options     head
 	exit when ${1};
-        ${0}
+	${0}
 
 snippet     put
 abbr        Ada.Text_IO.Put
 options     head
 	Ada.Text_IO.Put(${1});
-        ${0}
+	${0}
 
 snippet     put_line
 abbr        Ada.Text_IO.Put_Line
 options     head
 	Ada.Text_IO.Put_Line(${1});
-        ${0}
+	${0}
 
 snippet     get
 abbr        Ada.Text_IO.Get
 options     head
 	Ada.Text_IO.Get(${1});
-        ${0}
+	${0}
 
 snippet     get_line
 abbr        Ada.Text_IO.Get_Line
 options     head
 	Ada.Text_IO.Get_Line(${1});
-        ${0}
+	${0}
 
 snippet     newline
 abbr        Ada.Text_IO.New_Line
 options     head
 	Ada.Text_IO.New_Line(${1:1});
-        ${0}
+	${0}

--- a/neosnippets/cpp.snip
+++ b/neosnippets/cpp.snip
@@ -68,9 +68,9 @@ abbr        static_assert(,"")
     static_assert( ${1}, "${2}" );${0}
 
 delete      namespace
-options     head
 snippet     namespace
 abbr        namespace {}
+options     head
     namespace ${1:#:name} {
         ${0:TARGET}
     } // namespace $1

--- a/neosnippets/erlang.snip
+++ b/neosnippets/erlang.snip
@@ -1,7 +1,5 @@
 snippet     helloworld
 options     head
-
-
   main(_) -> io:format("Hello, world!\n").
 
 snippet     -module

--- a/neosnippets/php.snip
+++ b/neosnippets/php.snip
@@ -15,7 +15,7 @@ abbr function () {}
 snippet php
 	<?php
 	${1:TARGET}
-    /* End of file ${2:filename}.php */
+	/* End of file ${2:filename}.php */
 
 snippet pecho
 	<?php echo ${1} ?>${0}

--- a/neosnippets/rst.snip
+++ b/neosnippets/rst.snip
@@ -61,8 +61,8 @@ snippet code_block
 abbr code
 options head
   .. code-block:: ${1:#:filetype}
-
-		${2:#:content}
+  
+  ${2:#:content}
 
 snippet link_raw
 abbr link_as_raw
@@ -102,7 +102,6 @@ options head
 
 snippet nested_list
 options head
-
   - ${1:#:text}
   -
   -

--- a/neosnippets/twig.snip
+++ b/neosnippets/twig.snip
@@ -16,9 +16,9 @@ options     head
 snippet     dump
 abbr        <pre> {{ dump(...) }} </pre>
 options     head
-    <pre>
- 		{{ dump(${0:TARGET}) }}
-    </pre>
+	<pre>
+		{{ dump(${0:TARGET}) }}
+	</pre>
 
 snippet     embed
 abbr        {% embed ... %} ... {% endembed %}


### PR DESCRIPTION
At present deoppet (Shougo/deoppet.nvim@a43cdab0fb3323dc4c12c3f0fcb858973bbb6622) raises parse error if a snippet has both of hard and soft tabs.