### PR TITLE
Java: Adding Alias for println() and adding printf()

### DIFF
--- a/neosnippets/java.snip
+++ b/neosnippets/java.snip
@@ -185,8 +185,14 @@ snippet main
 
 
 snippet println
+alias sout
 options word
     System.out.println(${1});
+
+snippet printf
+alias souf
+options word
+    System.out.printf("${1}", ${2});
 
 snippet print
 options word


### PR DESCRIPTION
When I code in vim I sometimes miss the println/printf shortcuts
from IntelliJ.
