### PR TITLE
c,cpp: Remove const from argv of main

### DIFF
--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -120,7 +120,7 @@ abbr        enum {}
 # hard-tab is necessary; C indent doesn't support this.
 snippet     main
 options     head
-	int main(int argc, char const* argv[])
+	int main(int argc, char* argv[])
 	{
 		${0:TARGET}
 		return 0;
@@ -129,7 +129,7 @@ options     head
 snippet     helloworld
 options     head
     #include <stdio.h>
-    int main(int argc, char const* argv[])
+    int main(int argc, char* argv[])
     {
         puts("hello, world!");
         return 0;

--- a/neosnippets/cpp.snip
+++ b/neosnippets/cpp.snip
@@ -95,7 +95,7 @@ snippet     helloworld
 abbr        #include<iostream> int main...
     #include <iostream>
 
-    int main(int argc, char const* argv[])
+    int main(int argc, char* argv[])
     {
         std::cout << "hello, world!" << std::endl;
         return 0;


### PR DESCRIPTION
The parameter argv of main with type 'char const * []' is incompatible
with libc getopt() and long variants, which expects a 'char * const []'.

Hence, we only have to getopt()-compatible variants for the type of
argv:
  1. char * []
  2. char * const []

Variant 1 is the one mentioned in the ISO C99 standard (§5.1.2.2.1) and
is the one used by the man page of getopt() or by cppreference.com on
the main function.