### PR TITLE
asciidoc: Add title alias to doc

### DIFF
--- a/neosnippets/asciidoc.snip
+++ b/neosnippets/asciidoc.snip
@@ -1,6 +1,7 @@
 # See https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/
 
 snippet doc
+alias title
 abbr Start a new document
 options head
     = ${1:Document Name}


### PR DESCRIPTION
Probably 'title' is a suggestive alternative to 'doc' to set the
document title.