### PR TITLE
tex: Add snippet for tikz-based figures

### DIFF
--- a/neosnippets/tex.snip
+++ b/neosnippets/tex.snip
@@ -503,6 +503,17 @@ alias   \begin{column} \column
 	\end{column}
 
 # ========== TikZ ==========
+snippet tikzfig
+alias   figuretikz
+	\begin{figure}[${1}]
+		\centering
+		\begin{tikzpicture}[${2}]
+			${3:TARGET}
+		\end{tikzpicture}
+		\caption{${4}}
+		\label{${5}}
+	\end{figure}
+
 snippet tikzpicture
 alias   \begin{tikzpicture}
 	\begin{tikzpicture}[${1}]


### PR DESCRIPTION
The majority of tikzpicture environments are part of a figure
environment, so there should be a combined snippet to add tikz-based
figures. The snippet text is a blending of the existing snippet texts of
figure and tikzpicture.