### PR TITLE
Complete out of #includes in C

### DIFF
--- a/neosnippets/c.snip
+++ b/neosnippets/c.snip
@@ -142,13 +142,13 @@ options     head
 snippet     inc
 options     head
 alias       #inc, #include
-    #include <${1:stdio}.h>
+    #include <${1:stdio}.h>${0}
 
 # #include "..."
 snippet     inc2
 options     head
 alias       #inc2, #include2
-    #include "${1}.h"
+    #include "${1}.h"${0}
 
 snippet     #if
 options     head


### PR DESCRIPTION
Making the `#include` consistent across C and CPP snippet. 

- Added a `${0}` target like CPP https://github.com/Shougo/neosnippet-snippets/blob/1315d10e60bd93483aaac4cc5a1623d13aede504/neosnippets/cpp.snip#L3-L12