### PR TITLE
go: Add funcfuzz snippet

### DIFF
--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -107,19 +107,17 @@ options     head
   case ${1:#:condition}:
     ${2:TARGET}
 
-snippet     funcTest
-abbr        func Test... (t *testing.T) { ... }
+snippet     functest
+abbr        func Test...(t *testing.T) { ... }
 options     head
-  func Test${1} (${2:t *testing.T}) {
-    for i := 0; i < ${3:t.N}; i++ {
-      ${4}
-    }
+  func Test${1}(${2:t *testing.T}) {
+    ${3}
   }
 
 snippet     funcbench
-abbr        func Benchmark... (b *testing.B) { ... }
+abbr        func Benchmark...(b *testing.B) { ... }
 options     head
-  func Benchmark${1} (${2:b *testing.B}) {
+  func Benchmark${1}(${2:b *testing.B}) {
     for i := 0; i < ${3:b.N}; i++ {
       ${4}
     }

--- a/neosnippets/go.snip
+++ b/neosnippets/go.snip
@@ -123,6 +123,15 @@ options     head
     }
   }
 
+snippet     funcfuzz
+abbr        func Fuzz...(f *testing.F) { ... }
+options     head
+  func Fuzz${1}(${2:f *testing.F}) {
+    f.Fuzz(func(t *testing.T, ${3:b []byte}) {
+      ${4}
+    })
+  }
+
 snippet     testtable
 abbr        var test = {...}{...} for {t.Run(){...}}
 options     head


### PR DESCRIPTION
This PR adds a snippet for Go fuzzing ([tutorial](https://go.dev/doc/tutorial/fuzz), [docs](https://pkg.go.dev/testing#F), [official usages](https://github.com/golang/go/search?q=%22f.Fuzz%28func%28%22)), also fixes the test snippet.